### PR TITLE
Keith/stability fixes/qgc cache worker

### DIFF
--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -86,7 +86,6 @@ signals:
 private:
     QQueue<QGCMapTask*>     _taskQueue;
     QMutex                  _mutex;
-    QMutex                  _waitmutex;
     QWaitCondition          _waitc;
     QString                 _databasePath;
     QSqlDatabase*           _db;

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -54,6 +54,8 @@ private slots:
     void        _lookupReady            (QHostInfo info);
 
 private:
+    void        _runTask                (QGCMapTask* task);
+
     void        _saveTile               (QGCMapTask* mtask);
     void        _getTile                (QGCMapTask* mtask);
     void        _getTileSets            (QGCMapTask* mtask);
@@ -74,7 +76,9 @@ private:
     bool        _findTileSetID          (const QString name, quint64& setID);
     void        _updateSetTotals        (QGCCachedTileSet* set);
     bool        _init                   ();
-    bool        _createDB               (QSqlDatabase *db, bool createDefault = true);
+    bool        _connectDB              ();
+    bool        _createDB               (QSqlDatabase& db, bool createDefault = true);
+    void        _disconnectDB           ();
     quint64     _getDefaultTileSet      ();
     void        _updateTotals           ();
     void        _deleteTileSet          (qulonglong id);
@@ -84,21 +88,21 @@ signals:
     void        internetStatus          (bool active);
 
 private:
-    QQueue<QGCMapTask*>     _taskQueue;
-    QMutex                  _mutex;
-    QWaitCondition          _waitc;
-    QString                 _databasePath;
-    QSqlDatabase*           _db;
-    bool                    _valid;
-    bool                    _failed;
-    quint64                 _defaultSet;
-    quint64                 _totalSize;
-    quint32                 _totalCount;
-    quint64                 _defaultSize;
-    quint32                 _defaultCount;
-    time_t                  _lastUpdate;
-    int                     _updateTimeout;
-    int                     _hostLookupID;
+    QQueue<QGCMapTask*>             _taskQueue;
+    QMutex                          _mutex;
+    QWaitCondition                  _waitc;
+    QString                         _databasePath;
+    QScopedPointer<QSqlDatabase>    _db;
+    bool                            _valid;
+    bool                            _failed;
+    quint64                         _defaultSet;
+    quint64                         _totalSize;
+    quint32                         _totalCount;
+    quint64                         _defaultSize;
+    quint32                         _defaultCount;
+    time_t                          _lastUpdate;
+    int                             _updateTimeout;
+    int                             _hostLookupID;
 };
 
 #endif // QGC_TILE_CACHE_WORKER_H

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -89,7 +89,7 @@ signals:
 
 private:
     QQueue<QGCMapTask*>             _taskQueue;
-    QMutex                          _mutex;
+    QMutex                          _taskQueueMutex;
     QWaitCondition                  _waitc;
     QString                         _databasePath;
     QScopedPointer<QSqlDatabase>    _db;

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -93,7 +93,7 @@ private:
     QWaitCondition                  _waitc;
     QString                         _databasePath;
     QScopedPointer<QSqlDatabase>    _db;
-    bool                            _valid;
+    std::atomic_bool                _valid;
     bool                            _failed;
     quint64                         _defaultSet;
     quint64                         _totalSize;


### PR DESCRIPTION
This fixes racey access on `QGCCacheWorker::_taskQueue` and `QGCCacheWorker::_valid`. It also has some slight refactoring to help readability and help ensure that exceptions thrown don't cause leaks in SQLite.


With diagrams.net, I have drawn two sequence diagrams. The first diagram shows the timing around the use of `_taskQueue` with `_mutex`. The second diagram shows the timing around the use of `_valid`.


![QGCCacheWorker _taskQueue is racey](https://user-images.githubusercontent.com/72767521/114184940-bdebc500-990a-11eb-8b5a-d015e33cf52d.png)

![QGCCacheWorker _valid is racey](https://user-images.githubusercontent.com/72767521/114184948-c04e1f00-990a-11eb-9e5f-2095adff9772.png)
